### PR TITLE
better handling of empty first names

### DIFF
--- a/Pod/Classes/GTContactsPicker.m
+++ b/Pod/Classes/GTContactsPicker.m
@@ -144,16 +144,16 @@
             }
             
             id firstName = CFBridgingRelease(ABRecordCopyValue(record, kABPersonFirstNameProperty));
-            person.firstName = firstName;
             
             id lastName = CFBridgingRelease(ABRecordCopyValue(record, kABPersonLastNameProperty));
-            person.lastName = lastName;
 
             if (!firstName && !lastName) {
-                firstName = CFBridgingRelease(ABRecordCopyValue(record, kABPersonOrganizationProperty));
-                person.firstName = firstName;
+                firstName = CFBridgingRelease(ABRecordCopyCompositeName(record));
             }
-            
+
+            person.firstName = firstName;
+            person.lastName = lastName;
+
             if (self.pickerStyle == GTContactsPickerStyleSingularEmail) {
                 [formattedPeople addObjectsFromArray:[self sinGularEmailAddressesForRecord:record
                                                                                   ofPerson:person]];


### PR DESCRIPTION
Now, if contact has empty last & first names, fetchAllContactsWithCompletionBlock
will use contact composite name instead of (potentially empty) organization name.

This will allow handle contacts with e.g. only nickname or middle name.
